### PR TITLE
adds common-issues, starting with wsl2 forwarding

### DIFF
--- a/common-issues.mdx
+++ b/common-issues.mdx
@@ -9,7 +9,7 @@ route: /common-issues
 
 ### Observed Issue
 
-Although `new SdkgenHttpServer.listen(port)` is being called and outputs `Listening on :::PORT` or similar to console, no connection can be stablished. Hence, no requests are received.
+Although `new SdkgenHttpServer.listen(port)` is being called and outputs `Listening on :::PORT` or similar to console, no connection can be established. Hence, no requests are received.
 
 ### Resolution
 

--- a/common-issues.mdx
+++ b/common-issues.mdx
@@ -15,8 +15,8 @@ Although `new SdkgenHttpServer.listen(port)` is being called and outputs `Listen
 
 WSL2 ports aren't always forwarded. Two solutions are appliable:
 - Use a default forwarded port (`3000` is most likely one of those);
-- Add a new port forwarding rule that includes the port you're using. Remember to also add this rule to Firewall Rules, otherwise it's probably going to be blocked.
+- Add a new port forwarding rule that includes the port you're using. Remember to also add this rule to Firewall Rules, otherwise it's probably going to be blocked. You can easily achieve this through the instructions seen [here](https://github.com/microsoft/WSL/issues/4150#issuecomment-504209723).
 
 ### Additional Information
 
-This is a known issue with WSL2 as seen on it's [official repository](https://github.com/microsoft/WSL/issues/4150). The reason this happens is WSL2 uses a completely new network system architecture, "changing from the default bridged network adapter to a hyper-v virtual network adapter". You can find more Information [here](https://github.com/microsoft/WSL/issues/4150#issuecomment-504209723).
+This is a known issue with WSL2 as seen on its [official repository](https://github.com/microsoft/WSL/issues/4150). The reason this happens is WSL2 uses a completely new network system architecture, "changing from the default bridged network adapter to a hyper-v virtual network adapter". You can find more information [here](https://github.com/microsoft/WSL/issues/4150#issuecomment-504209723).

--- a/common-issues.mdx
+++ b/common-issues.mdx
@@ -1,0 +1,22 @@
+---
+name: Common Issues
+route: /common-issues
+---
+
+# Common Issues
+
+## Requests aren't received when using WSL2
+
+### Observed Issue
+
+Although `new SdkgenHttpServer.listen(port)` is being called and outputs `Listening on :::PORT` or similar to console, no connection can be stablished. Hence, no requests are received.
+
+### Resolution
+
+WSL2 ports aren't always forwarded. Two solutions are appliable:
+- Use a default forwarded port (`3000` is most likely one of those);
+- Add a new port forwarding rule that includes the port you're using. Remember to also add this rule to Firewall Rules, otherwise it's probably going to be blocked.
+
+### Additional Information
+
+This is a known issue with WSL2 as seen on it's [official repository](https://github.com/microsoft/WSL/issues/4150). The reason this happens is WSL2 uses a completely new network system architecture, "changing from the default bridged network adapter to a hyper-v virtual network adapter". You can find more Information [here](https://github.com/microsoft/WSL/issues/4150#issuecomment-504209723).

--- a/doczrc.js
+++ b/doczrc.js
@@ -4,6 +4,7 @@ export default {
         "Intro",
         "Getting Started",
         "Defining your schema",
-        "Encode and Decode"
+        "Encode and Decode",
+        "Common Issues"
     ]
 };


### PR DESCRIPTION
Page structure is slightly based on [Microsoft's Azure](https://docs.microsoft.com/pt-br/azure/cyclecloud/common-issues/execute_command?view=cyclecloud-7).

Can be understood as a tree:

- Common Issues
    - Issue name
        - Observed Issue (Issue Description)
        - Resolution (Simple, straightforward solution)
        - Additional Information (Any remaining info, references, more context)

If done accordingly to this proposal, the repeating part shall be "Issue name" and its children.